### PR TITLE
Upgrade selenium from 3.14 to 4.3

### DIFF
--- a/src/pypom/selenium_driver.py
+++ b/src/pypom/selenium_driver.py
@@ -129,7 +129,7 @@ def register():
             Chrome,
             Ie,
             Edge,
-            Opera,
+#             Opera,
             Safari,
             Remote,
             EventFiringWebDriver,

--- a/src/pypom/selenium_driver.py
+++ b/src/pypom/selenium_driver.py
@@ -9,7 +9,7 @@ from selenium.webdriver import (
     Edge,
     Firefox,
     Ie,
-    Opera,
+#     Opera,
     Remote,
     Safari,
 )


### PR DESCRIPTION
Looks like new selenium don't know anything about Opera.

```
/usr/local/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:986: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:680: in _load_unlocked
    ???
/usr/local/lib/python3.9/site-packages/_pytest/assertion/rewrite.py:170: in exec_module
    exec(co, module.__dict__)
tests/functional/conftest.py:10: in <module>
    from . import pages
tests/functional/pages/__init__.py:1: in <module>
    from .page_main import MainPage
tests/functional/pages/page_main.py:5: in <module>
    from .base import BasePage
tests/functional/pages/base.py:9: in <module>
    from pypom import Page
/usr/local/lib/python3.9/site-packages/pypom/__init__.py:8: in <module>
    from .selenium_driver import register as registerSelenium
/usr/local/lib/python3.9/site-packages/pypom/selenium_driver.py:7: in <module>
    from selenium.webdriver import (
E   ImportError: cannot import name 'Opera' from 'selenium.webdriver' (/usr/local/lib/python3.9/site-packages/selenium/webdriver/__init__.py)
```